### PR TITLE
Add round-robin support, fix type error

### DIFF
--- a/sfz2bitwig.py
+++ b/sfz2bitwig.py
@@ -366,7 +366,7 @@ class Multisample(object):
                 str1 = fid.read(8)
                 size, id = struct.unpack('<ii',str1)
                 size = size + (size % 2)                              # the size should be even, see WAV specfication, e.g. 16=>16, 23=>24
-                label = fid.read(size-4).rstrip('\x00')               # remove the trailing null characters
+                label = fid.read(size-4).rstrip(b'\x00')               # remove the trailing null characters
                 #_cuelabels.append(label)
                 _markersdict[id]['label'] = label                           # needed to match labels and markers
 

--- a/sfz2bitwig.py
+++ b/sfz2bitwig.py
@@ -133,6 +133,15 @@ class Multisample(object):
                         newsample['loopstop'] = v
                     elif k == "trigger":
                         newsample['trigger'] = v
+                    elif k == "lorand":
+                        if float(v) > 0.0:
+                            newsample['playlogic'] = "conditional"
+                    elif k == "hirand":
+                        if float(v) < 1.0:
+                            newsample['playlogic'] = "conditional"
+                    elif k == "seq_length":
+                        if int(v) > 1:
+                            newsample['playlogic'] = "conditional"
                     else:
                         sfz_opcodes_ignored["{}={}".format(k,v)] += 1
 
@@ -243,7 +252,8 @@ class Multisample(object):
         xml += '   <layer name="Default">\n'
 
         for sample in self.samples:
-            xml += '      <sample file="{}" gain="{}" sample-start="{}" sample-stop="{}">\n'.format(os.path.basename(sample.get('file','')),sample.get('gain','0.00'),sample.get('sample-start','0.000'),sample.get('sample-stop','0.000'))
+            zonelogic = 'round-robin' if sample.get('playlogic') == "conditional" else 'always-play'
+            xml += '      <sample file="{}" gain="{}" sample-start="{}" sample-stop="{}" zone-logic="{}">\n'.format(os.path.basename(sample.get('file','')),sample.get('gain','0.00'),sample.get('sample-start','0.000'),sample.get('sample-stop','0.000'),zonelogic)
             xml += '         <key high="{}" low="{}" root="{}" track="{}" tune="{}"/>\n'.format(sample.get('keyhigh',''),sample.get('keylow',''),sample.get('root',''),sample.get('track','true'),sample.get('tune','0.0'))
             vhigh = int(sample.get('velocityhigh','127'))
             vlow = int(sample.get('velocitylow','0'))


### PR DESCRIPTION
I noticed that Versilian Studios Chamber Orchestra 2 currently does not translate correctly either in sfz2bitwig or Bitwig's native SFZ conversion, as it uses the `lorand` and `hirand` opcodes to create a diceroll-based round-robin effect. The sample variations simply end up being layered on top of each other. My fork fixes this problem, in addition to translating sequential round robin.

Additionally, the wav loop point extraction was throwing an exception on my system due to expecting a `bytes` argument but getting a string, perhaps due to newer versions of Python having stricter type enforcement?